### PR TITLE
doubles for precision windows

### DIFF
--- a/spectral_window.pro
+++ b/spectral_window.pro
@@ -24,10 +24,10 @@ function spectral_window, n_samples, type = type, periodic = periodic, $
     n_use = n_samples
   endelse
 
-  cos_term1 = cos(2.*!pi*findgen(n_use)/(n_use-1))
-  cos_term2 = cos(4.*!pi*findgen(n_use)/(n_use-1))
-  cos_term3 = cos(6.*!pi*findgen(n_use)/(n_use-1))
-  cos_term4 = cos(8.*!pi*findgen(n_use)/(n_use-1))
+  cos_term1 = cos(2.*!pi*dindgen(n_use)/(n_use-1))
+  cos_term2 = cos(4.*!pi*dindgen(n_use)/(n_use-1))
+  cos_term3 = cos(6.*!pi*dindgen(n_use)/(n_use-1))
+  cos_term4 = cos(8.*!pi*dindgen(n_use)/(n_use-1))
 
   case type of
     'Hann': window = 0.5 * (1-cos_term1)
@@ -43,7 +43,7 @@ function spectral_window, n_samples, type = type, periodic = periodic, $
       endif else begin
         alpha = 0.5
       endelse
-      window = FLTARR(n_samples) + 1
+      window = DBLARR(n_samples) + 1
 
       edge_length = round(alpha*(n_use-1)/2.)
       if edge_length gt 0 then begin


### PR DESCRIPTION
The current code creates spectral windows as floats. The resulting fft of a Blackman-Harris has sidelobe structure constrained at the float level

<img width="590" alt="Screen Shot 2019-06-28 at 5 08 50 pm" src="https://user-images.githubusercontent.com/5588290/60324277-c2f6b300-99c7-11e9-81fc-19def6c99596.png">

If we change it to double precision, it looks like this 
<img width="593" alt="Screen Shot 2019-06-28 at 5 07 53 pm" src="https://user-images.githubusercontent.com/5588290/60324310-d1dd6580-99c7-11e9-8593-0115b64cb24e.png">

Here is the difference PS between a float and double Blackman-Harris spectral window. The k0 has changed because the sidelobes affect the integral of the window, which is used to normalize.
![MWA_limit2019_fullimg_ch9-126_averemove_swbh_dencorr__btl_noalltv_noocc4_minus_btl_noalltv_noocc4_2dkpower](https://user-images.githubusercontent.com/5588290/60324392-02bd9a80-99c8-11e9-8c52-aab85afb5b99.png)
